### PR TITLE
Add search for MSBuild.exe in the current VS2017 install folder

### DIFF
--- a/src/ResolveUR.Library/Constants.cs
+++ b/src/ResolveUR.Library/Constants.cs
@@ -7,15 +7,20 @@
         public const string X86 = "x86";
         public const string X64 = "x64";
 
-        public const string Msbuildx8620 = @"C:\Windows\Microsoft.Net\Framework\v2.0.50727\MSBuild.exe";
-        public const string Msbuildx8635 = @"C:\Windows\Microsoft.Net\Framework\v3.5\MSBuild.exe";
-        public const string Msbuildx8640 = @"C:\Windows\Microsoft.Net\Framework\v4.0.30319\MSBuild.exe";
-        public const string Msbuildx86V12 = @"C:\Program Files\MSBuild\12.0\bin\MSBuild.exe";
-        public const string Msbuildx86V14 = @"C:\Program Files\MSBuild\14.0\bin\MSBuild.exe";
-        public const string Msbuildx6420 = @"C:\Windows\Microsoft.Net\Framework64\v2.0.50727\MSBuild.exe";
-        public const string Msbuildx6435 = @"C:\Windows\Microsoft.Net\Framework64\v3.5\MSBuild.exe";
-        public const string Msbuildx6440 = @"C:\Windows\Microsoft.Net\Framework64\v4.0.30319\MSBuild.exe";
-        public const string Msbuildx64V12 = @"C:\Program Files (x86)\MSBuild\12.0\bin\MSBuild.exe";
-        public const string Msbuildx64V14 = @"C:\Program Files (x86)\MSBuild\14.0\bin\MSBuild.exe";
+        public const string Msbuildx8620 = @"%WINDIR%\Microsoft.Net\Framework\v2.0.50727\MSBuild.exe";
+        public const string Msbuildx8635 = @"%WINDIR%\Microsoft.Net\Framework\v3.5\MSBuild.exe";
+        public const string Msbuildx8640 = @"%WINDIR%\Microsoft.Net\Framework\v4.0.30319\MSBuild.exe";
+        public const string Msbuildx86V12 = @"%PROGRAMFILES%\MSBuild\12.0\bin\MSBuild.exe";
+        public const string Msbuildx86V14 = @"%PROGRAMFILES%\MSBuild\14.0\bin\MSBuild.exe";
+        public const string Msbuildx86VS = @"%VSAPPIDDIR%\..\..\MSBuild\%VisualStudioVersion%\bin\msbuild.exe";
+        public const string Msbuildx86VSCmd = @"%VSINSTALLDIR%\MSBuild\%VisualStudioVersion%\bin\msbuild.exe";
+
+        public const string Msbuildx6420 = @"%WINDIR%\Microsoft.Net\Framework64\v2.0.50727\MSBuild.exe";
+        public const string Msbuildx6435 = @"%WINDIR%\Microsoft.Net\Framework64\v3.5\MSBuild.exe";
+        public const string Msbuildx6440 = @"%WINDIR%\Microsoft.Net\Framework64\v4.0.30319\MSBuild.exe";
+        public const string Msbuildx64V12 = @"%PROGRAMFILES(X86)%\MSBuild\12.0\bin\MSBuild.exe";
+        public const string Msbuildx64V14 = @"%PROGRAMFILES(X86)%\MSBuild\14.0\bin\MSBuild.exe";
+        public const string Msbuildx64VS = @"%VSAPPIDDIR%\..\..\MSBuild\%VisualStudioVersion%\bin\amd64\msbuild.exe";
+        public const string Msbuildx64VSCmd = @"%VSINSTALLDIR%\MSBuild\%VisualStudioVersion%\bin\amd64\msbuild.exe";
     }
 }

--- a/src/ResolveUR.Library/MsBuildResolveUR.cs
+++ b/src/ResolveUR.Library/MsBuildResolveUR.cs
@@ -1,5 +1,7 @@
 ﻿namespace ResolveUR.Library
 {
+    using System;
+    using System.Collections.Generic;
     using System.IO;
 
     public class MsBuildResolveUR
@@ -21,6 +23,7 @@
                     case Constants.X64:
                         path = GetX64Path();
                         break;
+
                     case Constants.X86:
                         path = GetX86Path();
                         break;
@@ -33,42 +36,44 @@
             return path;
         }
 
-        static string GetX86Path()
+        private static string GetX64Path()
         {
-            if (File.Exists(Constants.Msbuildx86V14))
-                return Constants.Msbuildx86V14;
-
-            if (File.Exists(Constants.Msbuildx86V12))
-                return Constants.Msbuildx86V12;
-
-            if (File.Exists(Constants.Msbuildx8640))
-                return Constants.Msbuildx8640;
-
-            if (File.Exists(Constants.Msbuildx8635))
-                return Constants.Msbuildx8635;
-
-            if (File.Exists(Constants.Msbuildx8620))
-                return Constants.Msbuildx8620;
-
-            return null;
+            return GetPath(new List<string>
+            {
+                Constants.Msbuildx64VSCmd,
+                Constants.Msbuildx64VS,
+                Constants.Msbuildx64V14,
+                Constants.Msbuildx64V12,
+                Constants.Msbuildx6440,
+                Constants.Msbuildx6435,
+                Constants.Msbuildx6420
+            });
         }
 
-        static string GetX64Path()
+        private static string GetX86Path()
         {
-            if (File.Exists(Constants.Msbuildx64V14))
-                return Constants.Msbuildx64V14;
+            return GetPath(new List<string>
+            {
+                Constants.Msbuildx86VSCmd,
+                Constants.Msbuildx86VS,
+                Constants.Msbuildx86V14,
+                Constants.Msbuildx86V12,
+                Constants.Msbuildx8640,
+                Constants.Msbuildx8635,
+                Constants.Msbuildx8620
+            });
+        }
 
-            if (File.Exists(Constants.Msbuildx64V12))
-                return Constants.Msbuildx64V12;
-
-            if (File.Exists(Constants.Msbuildx6440))
-                return Constants.Msbuildx6440;
-
-            if (File.Exists(Constants.Msbuildx6435))
-                return Constants.Msbuildx6435;
-
-            if (File.Exists(Constants.Msbuildx6420))
-                return Constants.Msbuildx6420;
+        private static string GetPath(List<string> searchPaths)
+        {
+            foreach (var path in searchPaths)
+            {
+                var msbuildPath = Environment.ExpandEnvironmentVariables(path);
+                if (File.Exists(msbuildPath))
+                {
+                    return msbuildPath;
+                }
+            }
 
             return null;
         }

--- a/src/ResolveUR.Library/MsBuildResolveUR.cs
+++ b/src/ResolveUR.Library/MsBuildResolveUR.cs
@@ -36,20 +36,6 @@
             return path;
         }
 
-        private static string GetX64Path()
-        {
-            return GetPath(new List<string>
-            {
-                Constants.Msbuildx64VSCmd,
-                Constants.Msbuildx64VS,
-                Constants.Msbuildx64V14,
-                Constants.Msbuildx64V12,
-                Constants.Msbuildx6440,
-                Constants.Msbuildx6435,
-                Constants.Msbuildx6420
-            });
-        }
-
         private static string GetX86Path()
         {
             return GetPath(new List<string>
@@ -61,6 +47,20 @@
                 Constants.Msbuildx8640,
                 Constants.Msbuildx8635,
                 Constants.Msbuildx8620
+            });
+        }
+
+        private static string GetX64Path()
+        {
+            return GetPath(new List<string>
+            {
+                Constants.Msbuildx64VSCmd,
+                Constants.Msbuildx64VS,
+                Constants.Msbuildx64V14,
+                Constants.Msbuildx64V12,
+                Constants.Msbuildx6440,
+                Constants.Msbuildx6435,
+                Constants.Msbuildx6420
             });
         }
 

--- a/src/ResolveUR.Library/MsBuildResolveUR.cs
+++ b/src/ResolveUR.Library/MsBuildResolveUR.cs
@@ -36,7 +36,7 @@
             return path;
         }
 
-        private static string GetX86Path()
+        static string GetX86Path()
         {
             return GetPath(new List<string>
             {
@@ -50,7 +50,7 @@
             });
         }
 
-        private static string GetX64Path()
+        static string GetX64Path()
         {
             return GetPath(new List<string>
             {
@@ -64,15 +64,13 @@
             });
         }
 
-        private static string GetPath(List<string> searchPaths)
+        static string GetPath(List<string> searchPaths)
         {
             foreach (var path in searchPaths)
             {
                 var msbuildPath = Environment.ExpandEnvironmentVariables(path);
                 if (File.Exists(msbuildPath))
-                {
                     return msbuildPath;
-                }
             }
 
             return null;


### PR DESCRIPTION
Fixes for issue #6 

It seems to be caused by the new syntax options in C# 7 which requires MSBuild 15; ResolveUR only supports version 14 and earlier.

I added logic to check the following paths for the current MSBuild.exe:

- %VSINSTALLDIR%\MSBuild\%VisualStudioVersion%\Bin\amd64\MSBuild.exe
- %VSAPPIDDIR%\..\..\MSBuild\%VisualStudioVersion%\Bin\amd64\MSBuild.exe
- %VSINSTALLDIR%\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe
- %VSAPPIDDIR%\..\..\MSBuild\%VisualStudioVersion%\Bin\MSBuild.exe
